### PR TITLE
Not-so-pessimistic version contraint on chef.

### DIFF
--- a/knife-role-spaghetti.gemspec
+++ b/knife-role-spaghetti.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-chef_version = ENV.key?('CHEF_VERSION') ? "= #{ENV['CHEF_VERSION']}" : ['~> 10.12.0']
+chef_version = ENV.key?('CHEF_VERSION') ? "= #{ENV['CHEF_VERSION']}" : ['~> 10.12']
 require File.expand_path('../lib/knife-role-spaghetti', __FILE__)
 
 Gem::Specification.new do |gem|


### PR DESCRIPTION
Allows 10.14.2 to be permissible.
