### PR TITLE
easier restriction on chef, makes it work with newer chef versions.

### DIFF
--- a/knife-role-spaghetti.gemspec
+++ b/knife-role-spaghetti.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-chef_version = ENV.key?('CHEF_VERSION') ? "= #{ENV['CHEF_VERSION']}" : ['~> 10.12']
+chef_version = ENV.key?('CHEF_VERSION') ? "= #{ENV['CHEF_VERSION']}" : ['>= 10.12.0']
 require File.expand_path('../lib/knife-role-spaghetti', __FILE__)
 
 Gem::Specification.new do |gem|


### PR DESCRIPTION
Depending on chef~>10.12 restricts too much, release restriction to >=.
