### PR TITLE
Fix to ignore any files without a .json extension found in the role_path...

### DIFF
--- a/lib/chef/knife/spaghetti.rb
+++ b/lib/chef/knife/spaghetti.rb
@@ -75,7 +75,7 @@ module KnifeRoleSpaghetti
 
         file_extension = File.extname(role_file)
         if file_extension != ".json" then
-          ui.info("Skipping '#{abspath}' as it doesn't have a '.json' extension")
+          ui.info("Skipping '#{abspath}': not a '.json' file")
           next
         end
 


### PR DESCRIPTION
Just a simple patch to skip over any files on the role_path that don't have a .json extension.  Otherwise it fails in a fairly non-helpful way.
